### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: |
+        pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchvision
+pillow

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,31 @@
+import os
+from tempfile import TemporaryDirectory
+import numpy as np
+from PIL import Image
+import torch
+
+from dataloader import load_training, load_testing
+
+
+def _create_dummy_dataset(root, domain, categories=2, images_per_cat=2):
+    base = os.path.join(root, domain, 'images')
+    for c in range(categories):
+        cat_dir = os.path.join(base, f'cat{c}')
+        os.makedirs(cat_dir, exist_ok=True)
+        for i in range(images_per_cat):
+            arr = (np.random.rand(64, 64, 3) * 255).astype('uint8')
+            Image.fromarray(arr).save(os.path.join(cat_dir, f'{i}.jpg'))
+
+
+def test_dataloaders_return_batches():
+    with TemporaryDirectory() as tmp:
+        _create_dummy_dataset(tmp, 'd1')
+        train_loader = load_training(tmp, 'd1', batch_size=2)
+        images, labels = next(iter(train_loader))
+        assert images.shape == (2, 3, 227, 227)
+        assert labels.shape == (2,)
+
+        test_loader = load_testing(tmp, 'd1', batch_size=2)
+        images, labels = next(iter(test_loader))
+        assert images.shape == (2, 3, 227, 227)
+        assert labels.shape == (2,)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,20 @@
+import torch
+import mmd
+from model import Alexnet_finetune, DCCNet
+
+def test_alexnet_forward():
+    net = Alexnet_finetune(num_classes=5)
+    x = torch.randn(2, 3, 227, 227)
+    y = net(x)
+    assert y.shape == (2, 5)
+
+def test_ddcnet_forward(monkeypatch):
+    def fake_mmd(source, target):
+        return torch.tensor(0.0)
+    monkeypatch.setattr(mmd, "mmd_linear", fake_mmd, raising=False)
+    net = DCCNet(num_classes=5)
+    s = torch.randn(2, 3, 227, 227)
+    t = torch.randn(2, 3, 227, 227)
+    y, loss = net(s, t)
+    assert y.shape == (2, 5)
+    assert torch.is_tensor(loss)


### PR DESCRIPTION
## Summary
- add unit tests for dataloaders and models
- add requirements file for CI
- run tests in GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883f2019b98832f86e81c1a1c4472a8